### PR TITLE
twitch: use app access token

### DIFF
--- a/functions/env.d.ts
+++ b/functions/env.d.ts
@@ -4,8 +4,8 @@ declare module "process" {
       interface ProcessEnv {
         YOUTUBE_API: string;
         TWITCH_API: string;
-        TWITCH_TOKEN: string;
         TWITCH_CLIENT_ID: string;
+        TWITCH_CLIENT_SECRET: string;
         TWIT_CASTING_TOKEN: string;
         YOUTUBE_CHANNELIDS_PATH: string;
         TWITCH_CHANNELIDS_PATH: string;

--- a/functions/src/demo.ts
+++ b/functions/src/demo.ts
@@ -27,17 +27,17 @@ export const getVspoYoutube = onRequest(
 );
 
 export const getVspoTwitch = onRequest(
-  { secrets: ["TWITCH_TOKEN", "TWITCH_CLIENT_ID"] },
+  { secrets: ["TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"] },
   async (req, res) => {
-    const TW_TOKEN = process.env.TWITCH_TOKEN;
     const TW_CLIENT_ID = process.env.TWITCH_CLIENT_ID;
+    const TW_CLIENT_SECRET = process.env.TWITCH_CLIENT_SECRET;
     const TW_CHANNELIDS_PATH = process.env.TWITCH_CHANNELIDS_PATH;
 
     const twChSnap = await db.ref(TW_CHANNELIDS_PATH).get();
     if (twChSnap.exists()) {
       const twStreams = await twitch.getStreams(
-        TW_TOKEN,
         TW_CLIENT_ID,
+        TW_CLIENT_SECRET,
         twChSnap.val()
       );
       res.send(twStreams);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,8 +17,8 @@ export const updateChannels = onSchedule(
     schedule: "0 15 * * *",
     secrets: [
       "YOUTUBE_API",
-      "TWITCH_TOKEN",
       "TWITCH_CLIENT_ID",
+      "TWITCH_CLIENT_SECRET",
       "TWIT_CASTING_TOKEN",
     ],
   },
@@ -40,15 +40,15 @@ export const updateChannels = onSchedule(
     }
 
     //twitch
-    const TW_TOKEN = process.env.TWITCH_TOKEN;
     const TW_CLIENT_ID = process.env.TWITCH_CLIENT_ID;
+    const TW_CLIENT_SECRET = process.env.TWITCH_CLIENT_SECRET;
     const TW_CHANNELIDS_PATH = process.env.TWITCH_CHANNELIDS_PATH;
 
     const twChSnap = await db.ref(TW_CHANNELIDS_PATH).get();
     if (twChSnap.exists()) {
       const twChannels = await twitch.getChannels(
-        TW_TOKEN,
         TW_CLIENT_ID,
+        TW_CLIENT_SECRET,
         twChSnap.val()
       );
       db.ref(`${DATA_URI}/twitch/channels`).set(twChannels);
@@ -103,20 +103,20 @@ export const updateYoutubeStreams = onSchedule(
 export const updateTwitchAndTwitCastingStreams = onSchedule(
   {
     schedule: "1,11,21,31,41,51 * * * *",
-    secrets: ["TWITCH_TOKEN", "TWITCH_CLIENT_ID", "TWIT_CASTING_TOKEN"],
+    secrets: ["TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET", "TWIT_CASTING_TOKEN"],
   },
   async (_) => {
     const DATA_URI = process.env.DATA_URI;
 
-    const TW_TOKEN = process.env.TWITCH_TOKEN;
     const TW_CLIENT_ID = process.env.TWITCH_CLIENT_ID;
+    const TW_CLIENT_SECRET = process.env.TWITCH_CLIENT_SECRET;
     const TW_CHANNELIDS_PATH = process.env.TWITCH_CHANNELIDS_PATH;
 
     const twChSnap = await db.ref(TW_CHANNELIDS_PATH).get();
     if (twChSnap.exists()) {
       const twStreams = await twitch.getStreams(
-        TW_TOKEN,
         TW_CLIENT_ID,
+        TW_CLIENT_SECRET,
         twChSnap.val()
       );
       db.ref(`${DATA_URI}/twitch/streams`).set(twStreams);

--- a/functions/src/twitch.ts
+++ b/functions/src/twitch.ts
@@ -1,17 +1,25 @@
 import axios from "axios";
 import { ChannelInfo, StreamInfo } from "./types";
 
+const authURL = "https://id.twitch.tv/oauth2/token";
 const baseURL = "https://api.twitch.tv/helix";
 
 const doGetRequestTwitch = async (
   url: string,
-  token: string,
-  clientId: string
+  clientId: string,
+  clientSecret: string
 ) => {
   try {
+    // get app access token
+    const authRes = await axios.post(authURL, {
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "client_credentials",
+    });
+
     const res = await axios.get(url, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${authRes.data.access_token}`,
         "Client-Id": clientId,
         "Content-Type": "application/json",
       },
@@ -24,8 +32,8 @@ const doGetRequestTwitch = async (
 };
 
 export const getChannels = async (
-  token: string,
   clientId: string,
+  clientSecret: string,
   channelIds: string[]
 ) => {
   const url = `${baseURL}/users?${channelIds
@@ -34,8 +42,8 @@ export const getChannels = async (
 
   const contents: { data: any[] } = await doGetRequestTwitch(
     url,
-    token,
-    clientId
+    clientId,
+    clientSecret
   );
 
   return contents.data.map(
@@ -48,8 +56,8 @@ export const getChannels = async (
 };
 
 export const getStreams = async (
-  token: string,
   clientId: string,
+  clientSecret: string,
   channelIds: string[]
 ) => {
   const url = `${baseURL}/streams?first=50&${channelIds
@@ -58,8 +66,8 @@ export const getStreams = async (
 
   const contents: { data: any[] } = await doGetRequestTwitch(
     url,
-    token,
-    clientId
+    clientId,
+    clientSecret,
   );
 
   return contents.data.map(


### PR DESCRIPTION
Twitch からの情報取得時に利用するトークンを失効しない App Access Token に切り替えます

https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#client-credentials-grant-flow

以下の環境変数の変更が必要です:

- `TWITCH_TOKEN` 削除
- `TWITCH_CLIENT_SECRET` 追加